### PR TITLE
Support OpenStack extended "security" snakeoil

### DIFF
--- a/crossbar/x86_64/Dockerfile.community
+++ b/crossbar/x86_64/Dockerfile.community
@@ -45,8 +45,9 @@ RUN    addgroup crossbar \
 
 # initialize a Crossbar.io node
 COPY ./node/ /node/
-RUN chown -R crossbar:crossbar /node
-
+RUN chown -R crossbar:root /node &&\
+    chmod g+w -R /node
+    
 # make /node a volume to allow external configuration
 VOLUME /node
 


### PR DESCRIPTION
If crossbar image is running in an environment where the user is swapped during start, so that the actual user that is executing the process is not `crossbar` but a random generated user UID. This is the case for OpenShift and other Kubernetes like setups.  In order to make this image run on OpenShift/Kubernetes it needs slight modification of permissions for the root group. 